### PR TITLE
Let user select Global Properties

### DIFF
--- a/Forms/MainWindow.xaml
+++ b/Forms/MainWindow.xaml
@@ -1,11 +1,12 @@
 ﻿<Fluent:RibbonWindow x:Class="MSBuildExplorer.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-         xmlns:Fluent="clr-namespace:Fluent;assembly=Fluent" 
-         xmlns:basic="clr-namespace:MSBuildExplorer.UserControls"
-                     Title="MSBuild Explorer 3" Height="650" Width="900"
-                     WindowStartupLocation="CenterScreen"  Icon="/MSBuildExplorer3;component/Resources/Images/MSBEX.ico"
-              MinHeight="650" MinWidth="750" Closing="Window_Closing">
+        xmlns:Fluent="clr-namespace:Fluent;assembly=Fluent" 
+        xmlns:basic="clr-namespace:MSBuildExplorer.UserControls"
+        
+        Title="MSBuild Explorer 3" Height="650" Width="900"
+        WindowStartupLocation="CenterScreen"  Icon="/MSBuildExplorer3;component/Resources/Images/MSBEX.ico"
+        MinHeight="650" MinWidth="750" Closing="Window_Closing">
   <DockPanel LastChildFill="True">
     <Fluent:Ribbon x:Name="fluentRibbon" DockPanel.Dock="Top" SelectedTabIndex="1">
       <Fluent:Ribbon.QuickAccessItems>
@@ -22,6 +23,10 @@
           <Fluent:Button Name="buttonExplorer" Header="Explorer" Icon="/MSBuildExplorer3;component/Resources/Images/32/tree.png" LargeIcon="/MSBuildExplorer3;component/Resources/Images/32/tree.png" Click="menuShowExplorer"/>
           <Fluent:Button Name="buttonBuildPad" Header="BuildPad" Icon="/MSBuildExplorer3;component/Resources/Images/32/spade.png" LargeIcon="/MSBuildExplorer3;component/Resources/Images/32/spade.png" Click="menuShowBuildPad"/>
           <Fluent:Button Name="buttonConsoleBuild" Header="Build" Icon="/MSBuildExplorer3;component/Resources/Images/32/build.png" LargeIcon="/MSBuildExplorer3;component/Resources/Images/32/build.png" Click="menuConsoleBuild"/>
+        </Fluent:RibbonGroupBox>
+        <Fluent:RibbonGroupBox Header="Global Properties" Width="200">
+          <Fluent:ComboBox Name="comboGlobalConfiguration" Header="Configuration" SelectionChanged="comboGlobalConfiguration_SelectionChanged" />
+          <Fluent:ComboBox Name="comboGlobalPlatform" Header="Platform" SelectionChanged="comboGlobalPlatform_SelectionChanged" Width="190" Margin="0,5,0,0" />
         </Fluent:RibbonGroupBox>
       </Fluent:RibbonTabItem>
       <Fluent:RibbonTabItem Header="RESOURCES">

--- a/Forms/MainWindow.xaml.cs
+++ b/Forms/MainWindow.xaml.cs
@@ -22,6 +22,8 @@ namespace MSBuildExplorer
             this.Top = userPrefs.WindowTop;
             this.Left = userPrefs.WindowLeft;
             this.WindowState = userPrefs.WindowState;
+
+            this.Explorer.T1.AddHandler(UserControls.TreeExplorer.PopulateEverything, new RoutedEventHandler(this.PopulateEverythingHandler));
         }
 
         private enum buildMode
@@ -141,6 +143,42 @@ namespace MSBuildExplorer
             this.BuildPad.Visibility = Visibility.Hidden;
             this.About.Visibility = Visibility.Hidden;
             this.Options.Visibility = Visibility.Hidden;
+        }
+
+        private bool LoadingGlobalProps = false;
+        private void PopulateEverythingHandler(object sender, RoutedEventArgs e)
+        {
+            DataModel.MSBuildFile root = this.Explorer.T1.RootFile;
+            try
+            {
+                LoadingGlobalProps = true;
+                this.comboGlobalConfiguration.ItemsSource = root.GlobalConfigurations;
+                this.comboGlobalPlatform.ItemsSource = root.GlobalPlatforms;
+
+                Microsoft.Build.Evaluation.ProjectProperty defaultConfig = root.ProjectFile.GetProperty("Configuration");
+                Microsoft.Build.Evaluation.ProjectProperty defaultPlatform = root.ProjectFile.GetProperty("Platform");
+
+                this.comboGlobalConfiguration.SelectedItem = defaultConfig.EvaluatedValue;
+                this.comboGlobalPlatform.SelectedItem = defaultPlatform.EvaluatedValue;
+            }
+            finally
+            {
+                LoadingGlobalProps = false;
+            }
+        }
+
+        private void comboGlobalConfiguration_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (LoadingGlobalProps) return;
+            String newConfig = e.AddedItems[0] as String;
+            this.Explorer.Reload("Configuration", newConfig);
+        }
+
+        private void comboGlobalPlatform_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (LoadingGlobalProps) return;
+            String newPlatform = e.AddedItems[0] as String;
+            this.Explorer.Reload("Platform", newPlatform);
         }
     }
 }

--- a/Internal/DataModel/MSBuildFile.cs
+++ b/Internal/DataModel/MSBuildFile.cs
@@ -21,6 +21,8 @@ namespace MSBuildExplorer.DataModel
             this.Items = new ObservableCollection<MSBuildItems>();
             this.Usings = new ObservableCollection<MSBuildUsing>();
             this.Imports = new ObservableCollection<MSBuildImport>();
+			this.GlobalConfigurations = new ObservableCollection<String>();
+			this.GlobalPlatforms = new ObservableCollection<String>();
         }
 
         public Project ProjectFile { get; set; }
@@ -35,7 +37,11 @@ namespace MSBuildExplorer.DataModel
 
         public ObservableCollection<MSBuildProperties> Properties { get; set; }
 
-        public ObservableCollection<MSBuildUsing> Usings { get; set; }
+		public ObservableCollection<String> GlobalConfigurations { get; set; }
+
+		public ObservableCollection<String> GlobalPlatforms { get; set; }
+
+		public ObservableCollection<MSBuildUsing> Usings { get; set; }
 
         public ObservableCollection<MSBuildItems> Items { get; set; }
 

--- a/UserControls/Main.xaml
+++ b/UserControls/Main.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:userControls="clr-namespace:MSBuildExplorer.UserControls"
              mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
+             d:DesignHeight="400" d:DesignWidth="900">
     <Grid>
         <Grid>
             <Grid.RowDefinitions>

--- a/UserControls/Main.xaml.cs
+++ b/UserControls/Main.xaml.cs
@@ -151,6 +151,11 @@ namespace MSBuildExplorer.UserControls
         {
             this.T1.LoadFile(new FileInfo(this.T1.RootFile.ProjectFile.FullPath), true);    
         }
+        public void Reload(String propertyName, String PropertyValue)
+        {
+            bool forceReload = true;
+            this.T1.LoadFile(new FileInfo(this.T1.RootFile.ProjectFile.FullPath), true, propertyName, PropertyValue, forceReload);
+        }
 
         public void Build()
         {
@@ -181,7 +186,7 @@ namespace MSBuildExplorer.UserControls
             this.ofd.Title = "Open";
             this.ofd.Multiselect = true;
             this.ofd.RestoreDirectory = true;
-            this.ofd.Filter = "MSBuild Files|*.msbuild;*.proj;*.properties;*.targets;*.tasks;*.csproj;*.vbproj;*.vcxproj;*.msbef|All files|*.*";
+            this.ofd.Filter = "MSBuild Files|*.msbuild;*.proj;*.props;*.properties;*.targets;*.tasks;*.csproj;*.vbproj;*.vcxproj;*.msbef|All files|*.*";
             this.ofd.FilterIndex = 0;
             this.ofd.ShowDialog();
             foreach (var s in this.ofd.FileNames)

--- a/UserControls/TreeExplorer.xaml.cs
+++ b/UserControls/TreeExplorer.xaml.cs
@@ -36,18 +36,18 @@ namespace MSBuildExplorer.UserControls
             InitializeComponent();
         }
 
-        public void LoadFile(FileInfo file, bool populate)
+        public void LoadFile(FileInfo file, bool populate, String propertyName = null, String propertyValue = null, bool forceReload = false)
         {
-            if (this.RootFile != null && this.RootFile.ProjectFile.FullPath == file.FullName)
+            if (this.RootFile != null && this.RootFile.ProjectFile.FullPath == file.FullName && !forceReload)
             {
                 return;
             }
 
             RaiseEvent(new RoutedEventArgs(TreeExplorer.StartExplore, this));
-            MSBuildFileEqualityComparer eq = new MSBuildFileEqualityComparer();
+            
             try
             {
-                this.RootFile = MSBuildHelper.GetFile(file);
+                this.RootFile = MSBuildHelper.GetFile(file, propertyName, propertyValue);
             }
             catch (Exception ex)
             {
@@ -55,7 +55,7 @@ namespace MSBuildExplorer.UserControls
                 RaiseEvent(new RoutedEventArgs(TreeExplorer.FailedExplore, this));
                 return;
             }
-
+            MSBuildFileEqualityComparer eq = new MSBuildFileEqualityComparer();
             if (this.files.Contains(this.RootFile, eq))
             {
                 int i = 0;


### PR DESCRIPTION
### Problem
The build explorer only showed the default configuration and platform

This was a problem if you were trying to inspect build properties for a
different configuration or platform than what was set as the default
in the build project file.

### Analysis
This is not a hard problem to solve. The msbuild API allows for setting
arbitrary properties as global variables. Not only that, the msbuild API also
has a nice property that gets all the possible configs and platforms that
currently exist inside of an msbuild file.

### Solution
Added two combo boxes to the main ribbon that display the current
configuration and platform for the file. This is front and center to indicate
to the user the importance fact that the properties are interpreted through
the lense of the config and platform and that they can change them

I also cleaned a few things up here.